### PR TITLE
Add GoReleaser release automation

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,0 +1,33 @@
+name: Release Go project
+
+on:
+  push:
+    tags:
+      - "*"
+
+env:
+  GO_VER: "1.21"
+
+jobs:
+  build-binaries:
+    name: GoReleaser build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go ${{ env.GO_VER }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VER }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@master
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+before:
+  hooks:
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - ppc64le
+      - s390x
+    ldflags:
+      - -X github.com/jtaleric/k8s-io/pkg/version.GitCommit={{.Commit}} -X github.com/jtaleric/k8s-io/pkg/version.BuildDate={{.Date}} -X github.com/jtaleric/k8s-io/pkg/version.Version={{.Version}}
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- .Tag }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@
 
 # Variables
 BINARY_NAME=k8s-io
-GO_VERSION=1.21
 PACKAGE=github.com/jtaleric/k8s-io
+GIT_COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+VERSION=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+LDFLAGS=-X $(PACKAGE)/pkg/version.Version=$(VERSION) -X $(PACKAGE)/pkg/version.GitCommit=$(GIT_COMMIT) -X $(PACKAGE)/pkg/version.BuildDate=$(BUILD_DATE)
 
 # Default target
 .PHONY: all
@@ -13,16 +16,16 @@ all: build
 .PHONY: build
 build:
 	@echo "Building $(BINARY_NAME)..."
-	go build -o $(BINARY_NAME) .
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) .
 
 # Build for multiple platforms
 .PHONY: build-all
 build-all:
 	@echo "Building for multiple platforms..."
-	GOOS=linux GOARCH=amd64 go build -o $(BINARY_NAME)-linux-amd64 .
-	GOOS=linux GOARCH=arm64 go build -o $(BINARY_NAME)-linux-arm64 .
-	GOOS=darwin GOARCH=amd64 go build -o $(BINARY_NAME)-darwin-amd64 .
-	GOOS=darwin GOARCH=arm64 go build -o $(BINARY_NAME)-darwin-arm64 .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME)-linux-amd64 .
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME)-linux-arm64 .
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME)-darwin-amd64 .
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME)-darwin-arm64 .
 
 # Clean build artifacts
 .PHONY: clean
@@ -36,4 +39,3 @@ deps:
 	@echo "Installing dependencies..."
 	go mod tidy
 	go mod download
-

--- a/main.go
+++ b/main.go
@@ -8,16 +8,23 @@ import (
 
 	"github.com/jtaleric/k8s-io/pkg/config"
 	"github.com/jtaleric/k8s-io/pkg/kubernetes"
+	"github.com/jtaleric/k8s-io/pkg/version"
 	"github.com/jtaleric/k8s-io/pkg/workloads"
 )
 
 func main() {
 	var (
-		configFile = flag.String("config", "config.yaml", "Path to configuration file")
-		cleanup    = flag.Bool("cleanup", false, "Cleanup resources and exit")
-		dryRun     = flag.Bool("dry-run", false, "Generate manifests without applying them")
+		configFile  = flag.String("config", "config.yaml", "Path to configuration file")
+		cleanup     = flag.Bool("cleanup", false, "Cleanup resources and exit")
+		dryRun      = flag.Bool("dry-run", false, "Generate manifests without applying them")
+		showVersion = flag.Bool("version", false, "Print version information and exit")
 	)
 	flag.Parse()
+
+	if *showVersion {
+		version.Print()
+		return
+	}
 
 	log.Println("Starting K8s-IO benchmark tool...")
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import "fmt"
+
+var (
+	Version   = "dev"
+	GitCommit = "none"
+	BuildDate = "unknown"
+)
+
+func Print() {
+	fmt.Printf("Version: %s\nGit Commit: %s\nBuild Date: %s\n", Version, GitCommit, BuildDate)
+}


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yml` for cross-platform binary builds (linux/darwin/windows on amd64/arm64/ppc64le/s390x)
- Add `.github/workflows/go-release.yml` triggered on tag push to automate GitHub Releases via GoReleaser
- Add `pkg/version` package and `-version` flag to embed and print build info
- Update `Makefile` to inject version/commit/date via ldflags on local builds

## Usage
To create a release, push a tag:
```
git tag v0.1.0
git push origin v0.1.0
```

## Test plan
- [x] `go vet ./...` passes
- [x] `make build` compiles successfully
- [x] `./k8s-io -version` prints version, commit, and build date